### PR TITLE
some optimizations for the freq_dist plot

### DIFF
--- a/snakemake/Snakefile_model_eval
+++ b/snakemake/Snakefile_model_eval
@@ -5,22 +5,16 @@ threads: 1
 # -----------------------------------------------------------------------------
 DATASET = os.path.splitext(os.path.basename(config["dataset"]))[0]
 REPRESENTATIONS = config["representations"]
-REPRESENTATIONS_NO_SELFIES = [r for r in REPRESENTATIONS if r != "SELFIES"]
-SEEDS = config["seeds"]
 FOLDS = config["folds"]
 ENUM_FACTORS = config["enum_factors"]
-METRICS = config["metrics"]
 OUTPUT_DIR = config['output_dir']
-MODEL_PARAMS = config['model_params']
-ERR_PPM = config['err_ppm']
 
 shell.executable("/bin/bash")
 
 wildcard_constraints:
     dataset=DATASET,
     repr='|'.join(REPRESENTATIONS),
-    fold='\d+',
-    seed='\d+'
+    fold='\d+'
 
 # -----------------------------------------------------------------------------
 

--- a/snakemake/config.json
+++ b/snakemake/config.json
@@ -1,13 +1,13 @@
 {
-  "output_dir": "data",
-  "dataset": "/path/to/<dataset>.txt",
-  "pubchem_tsv_file": "/path/to/PubChem.tsv",
+  "output_dir": "/media/vineetb/T7/projects/nps/data/output/npmrd_plants",
+  "dataset": "/media/vineetb/T7/projects/nps/data/npmrd_plants.txt",
+  "pubchem_tsv_file": "/media/vineetb/T7/projects/nps/data/PubChem_with_fps.tsv",
 
   "representations": ["SMILES"],
   "folds": 10,
-  "train_seeds": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  "train_seeds": [0, 1, 2],
   "sample_seeds": [0],
-  "enum_factors": [0, 10, 30, 50, 100],
+  "enum_factors": [30],
   "max_input_smiles": 0,
 
   "model_params": {
@@ -30,5 +30,5 @@
   "min_tc": 0,
   "top_k": 30,
   "err_ppm": 10,
-  "random_seed": null
+  "random_seed": 5831
 }

--- a/snakemake/config.json
+++ b/snakemake/config.json
@@ -1,13 +1,13 @@
 {
-  "output_dir": "/media/vineetb/T7/projects/nps/data/output/npmrd_plants",
-  "dataset": "/media/vineetb/T7/projects/nps/data/npmrd_plants.txt",
-  "pubchem_tsv_file": "/media/vineetb/T7/projects/nps/data/PubChem_with_fps.tsv",
+  "output_dir": "data",
+  "dataset": "/path/to/<dataset>.txt",
+  "pubchem_tsv_file": "/path/to/PubChem.tsv",
 
   "representations": ["SMILES"],
   "folds": 10,
-  "train_seeds": [0, 1, 2],
+  "train_seeds": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
   "sample_seeds": [0],
-  "enum_factors": [30],
+  "enum_factors": [0, 10, 30, 50, 100],
   "max_input_smiles": 0,
 
   "model_params": {
@@ -30,5 +30,5 @@
   "min_tc": 0,
   "top_k": 30,
   "err_ppm": 10,
-  "random_seed": 5831
+  "random_seed": null
 }

--- a/src/clm/commands/write_freq_distribution.py
+++ b/src/clm/commands/write_freq_distribution.py
@@ -1,7 +1,10 @@
 import argparse
-
+import logging
 import pandas as pd
 from clm.functions import read_file
+
+
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -15,10 +18,13 @@ def add_args(parser):
 
 
 def write_freq_distribution(sampled_file, test_file, output_file):
+    logger.info(f"Reading sampled data from {sampled_file}")
     sampled_data = pd.read_csv(sampled_file)
+    logger.info(f"Reading test smiles from {test_file}")
     test_smiles = set(read_file(test_file, stream=True, smile_only=True))
 
     # Label smiles not found in test set as novel
+    logger.info("Finding novel smiles in sampled data")
     sampled_data["is_novel"] = True
     sampled_data.loc[sampled_data["smiles"].isin(test_smiles), "is_novel"] = False
 


### PR DESCRIPTION
Some modifications to prevent the (40min+?) time it previously took to plot frequency distributions. I also noticed that it consumed all my 64G memory and I wasn't able to complete it locally anyway, so there are some memory optimizations too.

 - only reading the columns we need in `pd.read_csv`.
 - discarding memory held by variables (lists, series etc) we don't need anymore, by reusing variable names
 - `.tolist()` at a couple of places where lists will suffice, to avoid the memory overhead of `pd.Series`
 - generation of `pd.DataFrame` using a list of dicts instead (supposed to be the fastest way to construct a DataFrame).
 - Not using `sns.boxplot` directly but in a slightly roundabout way (this was the main culprit in the long runtime).
 - logging at several steps to avoid wondering what's going on.
 
 Also removed some configuration options from `Snakefile_model_eval` which are not used (`seeds` is gone in favor of `train_seeds` and `sample_seeds`, for example, so perhaps its best not to get config variables we don't actually use).