### PR TITLE
Issue 126 (Calculate outcomes tweak)

### DIFF
--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -48,12 +48,6 @@ def add_args(parser):
     )
     parser.add_argument("--output_file", type=str)
     parser.add_argument(
-        "--max_orig_mols",
-        type=int,
-        default=None,
-        help="Max number of sampled smiles to process from each frequency bin.",
-    )
-    parser.add_argument(
         "--seed", type=seed_type, default=None, nargs="?", help="Random seed"
     )
     return parser
@@ -134,14 +128,12 @@ def calculate_probabilities(*dicts):
     return return_values
 
 
-def get_dataframes(train_file, sampled_file, max_orig_mols=None):
+def get_dataframes(train_file, sampled_file):
     logger.info(f"Reading training smiles from {train_file}")
     train_df = smile_properties_dataframe(train_file)
 
     logger.info(f"Reading sample smiles from {sampled_file}")
-    sample_smiles_df = smile_properties_dataframe(
-        sampled_file, max_smiles=max_orig_mols
-    )
+    sample_smiles_df = smile_properties_dataframe(sampled_file)
 
     sample_smiles_df["is_valid"] = sample_smiles_df.apply(
         lambda row: row["canonical_smile"] is not None, axis=1
@@ -274,11 +266,9 @@ def calculate_outcomes_dataframe(sample_df, train_df):
     return out
 
 
-def calculate_outcomes(
-    sampled_file, train_file, output_file, max_orig_mols=None, seed=None
-):
+def calculate_outcomes(sampled_file, train_file, output_file, seed=None):
     set_seed(seed)
-    train_df, sample_df = get_dataframes(train_file, sampled_file, max_orig_mols)
+    train_df, sample_df = get_dataframes(train_file, sampled_file)
 
     logger.info("Calculating outcomes")
     out = calculate_outcomes_dataframe(sample_df, train_df)
@@ -295,7 +285,6 @@ def main(args):
         train_file=args.train_file,
         sampled_file=args.sampled_file,
         output_file=args.output_file,
-        max_orig_mols=args.max_orig_mols,
         seed=args.seed,
     )
 

--- a/src/clm/commands/inner_prep_outcomes_freq.py
+++ b/src/clm/commands/inner_prep_outcomes_freq.py
@@ -1,8 +1,10 @@
 import argparse
+import logging
 import pandas as pd
 from clm.functions import set_seed, seed_type
 
 parser = argparse.ArgumentParser(description=__doc__)
+logger = logging.getLogger(__name__)
 
 
 def add_args(parser):
@@ -38,10 +40,14 @@ def prep_outcomes_freq(samples, max_molecules, output_file=None, seed=None):
         else:
             selected_rows = data[data["size"] > f_min]
 
+        bin_name = f"{f_min}-{f_max}" if f_max is not None else f"{f_min}-"
+
         if max_molecules is not None and len(selected_rows) > max_molecules:
             selected_rows = selected_rows.sample(n=max_molecules)
-
-        bin_name = f"{f_min}-{f_max}" if f_max is not None else f"{f_min}-"
+        elif max_molecules is not None and len(selected_rows) < max_molecules:
+            logger.warning(
+                f"Not enough molecules for frequency bin '{bin_name}'. Using {len(selected_rows)} molecules."
+            )
 
         data.loc[selected_rows.index, "bin"] = bin_name
 

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -46,7 +46,6 @@ def test_calculate_outcomes():
             # For LOTUS, train/test "_all.smi" files are the same
             train_file=test_dir / "test_LOTUS_SMILES_all_trunc.smi",
             output_file=output_file,
-            max_orig_mols=10000,
             seed=12,
         )
 


### PR DESCRIPTION
- No longer truncating smiles from calculate_outcomes. The required number of molecules for a particular frequency bin is extracted on `inner_prep_calculate_outcomes`
- Setting up a logger.warning  message if a bin doesn't meet minimum number of molecules needed