### PR TITLE
indexing range fix with several calculate_outcomes metrics

### DIFF
--- a/src/clm/functions.py
+++ b/src/clm/functions.py
@@ -275,6 +275,8 @@ def seed_type(value):
 
 
 def continuous_JSD(generated_dist, original_dist, tol=1e-10):
+    if len(generated_dist) < 2:  # not enough points?
+        return np.nan
     try:
         gen_kde = gaussian_kde(generated_dist)
     except np.linalg.LinAlgError:
@@ -308,8 +310,8 @@ def internal_diversity(fps, sample_size=1e4, summarise=True):
     tcs = []
     counter = 0
     while counter < sample_size:
-        idx1 = np.random.randint(0, len(fps) - 1)
-        idx2 = np.random.randint(0, len(fps) - 1)
+        idx1 = np.random.randint(0, len(fps))
+        idx2 = np.random.randint(0, len(fps))
         fp1 = fps[idx1]
         fp2 = fps[idx2]
         tcs.append(FingerprintSimilarity(fp1, fp2))
@@ -329,8 +331,8 @@ def external_diversity(fps1, fps2, sample_size=1e4, summarise=True):
     tcs = []
     counter = 0
     while counter < sample_size:
-        idx1 = np.random.randint(0, len(fps1) - 1)
-        idx2 = np.random.randint(0, len(fps2) - 1)
+        idx1 = np.random.randint(0, len(fps1))
+        idx2 = np.random.randint(0, len(fps2))
         fp1 = fps1[idx1]
         fp2 = fps2[idx2]
         tcs.append(FingerprintSimilarity(fp1, fp2))
@@ -352,13 +354,17 @@ def internal_nn(fps, sample_size=1e3, summarise=True):
     counter = 0
     nns = []
     while counter < sample_size:
-        idx1 = np.random.randint(0, len(fps) - 1)
+        idx1 = np.random.randint(0, len(fps))
         fp1 = fps[idx1]
         tcs = []
         for idx2 in range(len(fps)):
             if idx1 != idx2:
                 fp2 = fps[idx2]
                 tcs.append(FingerprintSimilarity(fp1, fp2))
+
+        if len(tcs) == 0:  # not enough fingerprints?
+            return np.nan
+
         nn = np.max(tcs)
         nns.append(nn)
         counter += 1
@@ -379,12 +385,16 @@ def external_nn(fps1, fps2, sample_size=1e3, summarise=True):
     counter = 0
     nns = []
     while counter < sample_size:
-        idx1 = np.random.randint(0, len(fps1) - 1)
+        idx1 = np.random.randint(0, len(fps1))
         fp1 = fps1[idx1]
         tcs = []
         for idx2 in range(len(fps2)):
             fp2 = fps2[idx2]
             tcs.append(FingerprintSimilarity(fp1, fp2))
+
+        if len(tcs) == 0:  # not enough fingerprints?
+            return np.nan
+
         nn = np.max(tcs)
         nns.append(nn)
         counter += 1

--- a/tests/test_data/calculate_outcome.csv
+++ b/tests/test_data/calculate_outcome.csv
@@ -35,18 +35,18 @@ bin,outcome,value,input_file
 1,"Jensen-Shannon distance, TPSA",0.2771490850624588,prep_outcomes_freq.csv
 2,"Jensen-Shannon distance, TPSA",0.1462992021448038,prep_outcomes_freq.csv
 3-10,"Jensen-Shannon distance, TPSA",0.1279191122686102,prep_outcomes_freq.csv
-1,Internal diversity,0.2879894093253645,prep_outcomes_freq.csv
-2,Internal diversity,0.2255781665992752,prep_outcomes_freq.csv
-3-10,Internal diversity,0.20839264432920532,prep_outcomes_freq.csv
-1,External diversity,0.2128125319900384,prep_outcomes_freq.csv
-2,External diversity,0.18947032891137294,prep_outcomes_freq.csv
-3-10,External diversity,0.17213497943924977,prep_outcomes_freq.csv
-1,Internal nearest-neighbor Tc,0.6002677865985644,prep_outcomes_freq.csv
-2,Internal nearest-neighbor Tc,0.6617378808658038,prep_outcomes_freq.csv
-3-10,Internal nearest-neighbor Tc,0.7388470263507588,prep_outcomes_freq.csv
-1,External nearest-neighbor Tc,0.5645213046329248,prep_outcomes_freq.csv
-2,External nearest-neighbor Tc,0.5312329173696364,prep_outcomes_freq.csv
-3-10,External nearest-neighbor Tc,0.500084860827164,prep_outcomes_freq.csv
+1,Internal diversity,0.2891086541457372,prep_outcomes_freq.csv
+2,Internal diversity,0.2271869740189818,prep_outcomes_freq.csv
+3-10,Internal diversity,0.20821541437816285,prep_outcomes_freq.csv
+1,External diversity,0.21386784412699153,prep_outcomes_freq.csv
+2,External diversity,0.1893080626530349,prep_outcomes_freq.csv
+3-10,External diversity,0.1731253171847298,prep_outcomes_freq.csv
+1,Internal nearest-neighbor Tc,0.5999185739011003,prep_outcomes_freq.csv
+2,Internal nearest-neighbor Tc,0.6658689572437837,prep_outcomes_freq.csv
+3-10,Internal nearest-neighbor Tc,0.745816333085296,prep_outcomes_freq.csv
+1,External nearest-neighbor Tc,0.5674728488532578,prep_outcomes_freq.csv
+2,External nearest-neighbor Tc,0.5333919122267488,prep_outcomes_freq.csv
+3-10,External nearest-neighbor Tc,0.501662584740084,prep_outcomes_freq.csv
 1,"Jensen-Shannon distance, # of rings",0.31278203464411025,prep_outcomes_freq.csv
 2,"Jensen-Shannon distance, # of rings",0.28783113998700494,prep_outcomes_freq.csv
 3-10,"Jensen-Shannon distance, # of rings",0.2890607751893959,prep_outcomes_freq.csv


### PR DESCRIPTION
In several places where we're calculating internal/external diversity with incoming fingerprints, we randomly sample certain fingerprints, but ignore the very last one because we do a `np.random.randint(0, n-1)` instead of `np.random.randint(0, n)`. This is probably a leftover from the R->python transition.

This changes the values slightly - only important for test cases here. No need to rerun any analyses of course.