### PR TITLE
print CLM version in use before any command invocation

### DIFF
--- a/src/clm/__main__.py
+++ b/src/clm/__main__.py
@@ -73,6 +73,8 @@ def main():
     args = parser.parse_args()
     if args.verbose:
         logger.setLevel(logging.DEBUG)
+
+    logger.info(f"CLM v{clm.__version__}")
     args.func(args)
 
 


### PR DESCRIPTION
Trivial modification but important when looking at logs, since I recently an enum factor `100` on the wrong version of CLM and didn't realize it till much later after having to run some forensics.