### PR TITLE
tmp_path fixture in tests; fixed tiny bug in the process

### DIFF
--- a/src/clm/commands/inner_sample_molecules_RNN.py
+++ b/src/clm/commands/inner_sample_molecules_RNN.py
@@ -1,6 +1,8 @@
 import argparse
 import logging
 import os.path
+
+import pandas as pd
 import torch
 from tqdm import tqdm
 
@@ -110,14 +112,12 @@ def sample_molecules_RNN(
 
     with tqdm(total=sample_mols) as pbar:
         for i in range(0, sample_mols, batch_size):
-            sampled_smiles, losses = model.sample(batch_size, return_losses=True)
-
-            write_to_csv_file(
-                output_file,
-                mode="w" if i == 0 else "a+",
-                info=zip(losses, sampled_smiles),
-                string_format="{0[0]:.4f}, {0[1]} \n",
+            sampled_smiles, losses = model.sample(
+                min(batch_size, sample_mols - i), return_losses=True
             )
+            df = pd.DataFrame(zip(losses, sampled_smiles), columns=["loss", "smiles"])
+
+            write_to_csv_file(output_file, mode="w" if i == 0 else "a+", info=df)
 
             pbar.update(batch_size)
 

--- a/src/clm/functions.py
+++ b/src/clm/functions.py
@@ -15,7 +15,10 @@ from scipy.stats import gaussian_kde
 from scipy.spatial.distance import jensenshannon
 import hashlib
 import gzip
+import logging
 
+
+logger = logging.getLogger(__name__)
 converter = deepsmiles.Converter(rings=True, branches=True)
 
 
@@ -502,6 +505,7 @@ def write_to_csv_file(
             compression=compression,
         )
     else:
+        logger.warning("Non-DataFrame input support will be removed soon")
         assert compression in (None, "gzip"), "Invalid compression type"
         if compression == "gzip":
             mode = "wb" if mode == "w" else "ab"  # binary mode for gzip

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,9 +1,7 @@
 import contextlib
-from pathlib import Path
 import pytest
 import numpy as np
 import seaborn as sns
-import tempfile
 import pandas as pd
 from clm.functions import read_file, read_csv_file, write_to_csv_file
 
@@ -146,91 +144,69 @@ def test_read_file_stream_5_randomize_compressed(dataset_compressed):
     assert data[3] == "CC1(C)C=Cc2c(cc(CO)c(C(=O)O)c2O)O1"  # Line 517
 
 
-def test_write_csv_uncompressed_dataframe():
+def test_write_csv_uncompressed_dataframe(tmp_path):
     iris = sns.load_dataset("iris")
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "iris.csv", iris)
-        df = read_csv_file(temp_dir / "iris.csv")
-        pd.testing.assert_frame_equal(iris, df)
+    write_to_csv_file(tmp_path / "iris.csv", iris)
+    df = read_csv_file(tmp_path / "iris.csv")
+    pd.testing.assert_frame_equal(iris, df)
 
 
-def test_write_csv_compressed_dataframe():
+def test_write_csv_compressed_dataframe(tmp_path):
     iris = sns.load_dataset("iris")
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "iris.csv.gz", iris)
-        df = read_csv_file(temp_dir / "iris.csv.gz")
-        pd.testing.assert_frame_equal(iris, df)
+    write_to_csv_file(tmp_path / "iris.csv.gz", iris)
+    df = read_csv_file(tmp_path / "iris.csv.gz")
+    pd.testing.assert_frame_equal(iris, df)
 
 
-def test_write_csv_uncompressed_iterable():
+def test_write_csv_uncompressed_iterable(tmp_path):
     data = ["foo", "bar", "baz"]
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "data.csv", data, string_format="{}\n")
-        df = read_csv_file(temp_dir / "data.csv", header=None)
-        pd.testing.assert_frame_equal(pd.DataFrame(data), df)
+    write_to_csv_file(tmp_path / "data.csv", data, string_format="{}\n")
+    df = read_csv_file(tmp_path / "data.csv", header=None)
+    pd.testing.assert_frame_equal(pd.DataFrame(data), df)
 
 
-def test_write_csv_compressed_iterable():
+def test_write_csv_compressed_iterable(tmp_path):
     data = ["foo", "bar", "baz"]
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "data.csv.gz", data, string_format="{}\n")
-        df = read_csv_file(temp_dir / "data.csv.gz", header=None)
-        pd.testing.assert_frame_equal(pd.DataFrame(data), df)
+    write_to_csv_file(tmp_path / "data.csv.gz", data, string_format="{}\n")
+    df = read_csv_file(tmp_path / "data.csv.gz", header=None)
+    pd.testing.assert_frame_equal(pd.DataFrame(data), df)
 
 
-def test_write_csv_uncompressed_dataframe_append():
+def test_write_csv_uncompressed_dataframe_append(tmp_path):
     iris = sns.load_dataset("iris")
     iris2 = iris.copy()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "iris.csv", iris)
-        write_to_csv_file(temp_dir / "iris.csv", iris2, mode="a+")
-        df = read_csv_file(temp_dir / "iris.csv")
-        pd.testing.assert_frame_equal(
-            pd.concat([iris, iris2]).reset_index(drop=True), df
-        )
+    write_to_csv_file(tmp_path / "iris.csv", iris)
+    write_to_csv_file(tmp_path / "iris.csv", iris2, mode="a+")
+    df = read_csv_file(tmp_path / "iris.csv")
+    pd.testing.assert_frame_equal(pd.concat([iris, iris2]).reset_index(drop=True), df)
 
 
-def test_write_csv_compressed_dataframe_append():
+def test_write_csv_compressed_dataframe_append(tmp_path):
     iris = sns.load_dataset("iris")
     iris2 = iris.copy()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "iris.csv.gz", iris)
-        write_to_csv_file(temp_dir / "iris.csv.gz", iris2, mode="a+")
-        df = read_csv_file(temp_dir / "iris.csv.gz")
-        pd.testing.assert_frame_equal(
-            pd.concat([iris, iris2]).reset_index(drop=True), df
-        )
+    write_to_csv_file(tmp_path / "iris.csv.gz", iris)
+    write_to_csv_file(tmp_path / "iris.csv.gz", iris2, mode="a+")
+    df = read_csv_file(tmp_path / "iris.csv.gz")
+    pd.testing.assert_frame_equal(pd.concat([iris, iris2]).reset_index(drop=True), df)
 
 
-def test_write_csv_uncompressed_iterable_append():
+def test_write_csv_uncompressed_iterable_append(tmp_path):
     data = ["foo", "bar", "baz"]
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "data.csv", data, string_format="{}\n")
-        write_to_csv_file(temp_dir / "data.csv", data, string_format="{}\n", mode="a+")
-        df = read_csv_file(temp_dir / "data.csv", header=None)
-        pd.testing.assert_frame_equal(
-            pd.concat([pd.DataFrame(data), pd.DataFrame(data)]).reset_index(drop=True),
-            df,
-        )
+    write_to_csv_file(tmp_path / "data.csv", data, string_format="{}\n")
+    write_to_csv_file(tmp_path / "data.csv", data, string_format="{}\n", mode="a+")
+    df = read_csv_file(tmp_path / "data.csv", header=None)
+    pd.testing.assert_frame_equal(
+        pd.concat([pd.DataFrame(data), pd.DataFrame(data)]).reset_index(drop=True),
+        df,
+    )
 
 
-def test_write_csv_compressed_iterable_append():
+def test_write_csv_compressed_iterable_append(tmp_path):
     data = ["foo", "bar", "baz"]
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        write_to_csv_file(temp_dir / "data.csv.gz", data, string_format="{}\n")
-        write_to_csv_file(
-            temp_dir / "data.csv.gz", data, string_format="{}\n", mode="a+"
-        )
-        df = read_csv_file(temp_dir / "data.csv.gz", header=None)
-        pd.testing.assert_frame_equal(
-            pd.concat([pd.DataFrame(data), pd.DataFrame(data)]).reset_index(drop=True),
-            df,
-        )
+    write_to_csv_file(tmp_path / "data.csv.gz", data, string_format="{}\n")
+    write_to_csv_file(tmp_path / "data.csv.gz", data, string_format="{}\n", mode="a+")
+    df = read_csv_file(tmp_path / "data.csv.gz", header=None)
+    pd.testing.assert_frame_equal(
+        pd.concat([pd.DataFrame(data), pd.DataFrame(data)]).reset_index(drop=True),
+        df,
+    )

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import tempfile
 import pandas as pd
 import pytest
 from clm.commands.calculate_outcomes import (
@@ -38,57 +37,55 @@ def test_generate_outcome_dicts():
     )
 
 
-def test_calculate_outcomes():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = Path(temp_dir) / "calculate_outcomes.csv"
-        outcomes = calculate_outcomes(
-            sampled_file=test_dir / "prep_outcomes_freq.csv",
-            # For LOTUS, train/test "_all.smi" files are the same
-            train_file=test_dir / "test_LOTUS_SMILES_all_trunc.smi",
-            output_file=output_file,
-            seed=12,
-        )
+def test_calculate_outcomes(tmp_path):
+    output_file = tmp_path / "calculate_outcomes.csv"
+    outcomes = calculate_outcomes(
+        sampled_file=test_dir / "prep_outcomes_freq.csv",
+        # For LOTUS, train/test "_all.smi" files are the same
+        train_file=test_dir / "test_LOTUS_SMILES_all_trunc.smi",
+        output_file=output_file,
+        seed=12,
+    )
 
-        true_outcomes = read_csv_file(
-            test_dir / "calculate_outcome.csv", keep_default_na=False
-        )
-        # https://stackoverflow.com/questions/14224172
-        pd.testing.assert_frame_equal(
-            outcomes.sort_index(axis=1)
-            .sort_values(["outcome", "bin"])
-            .reset_index(drop=True),
-            true_outcomes.sort_index(axis=1)
-            .sort_values(["outcome", "bin"])
-            .reset_index(drop=True),
-        )
+    true_outcomes = read_csv_file(
+        test_dir / "calculate_outcome.csv", keep_default_na=False
+    )
+    # https://stackoverflow.com/questions/14224172
+    pd.testing.assert_frame_equal(
+        outcomes.sort_index(axis=1)
+        .sort_values(["outcome", "bin"])
+        .reset_index(drop=True),
+        true_outcomes.sort_index(axis=1)
+        .sort_values(["outcome", "bin"])
+        .reset_index(drop=True),
+    )
 
-        plot(
-            evaluation_type="calculate_outcomes",
-            outcome_dir=temp_dir,
-            output_dir=temp_dir,
-        )
+    plot(
+        evaluation_type="calculate_outcomes",
+        outcome_dir=tmp_path,
+        output_dir=tmp_path,
+    )
 
 
-def test_prep_nn_tc():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = Path(temp_dir) / "prep_nn_tc_PubChem.csv"
-        outcomes = prep_nn_tc(
-            sample_file=test_dir / "prep_nn_tc_input.csv",
-            max_molecules=100,
-            pubchem_file=test_dir / "PubChem_truncated.tsv",
-            output_file=output_file,
-            seed=0,
-        )
+def test_prep_nn_tc(tmp_path):
+    output_file = tmp_path / "prep_nn_tc_PubChem.csv"
+    outcomes = prep_nn_tc(
+        sample_file=test_dir / "prep_nn_tc_input.csv",
+        max_molecules=100,
+        pubchem_file=test_dir / "PubChem_truncated.tsv",
+        output_file=output_file,
+        seed=0,
+    )
 
-        true_outcomes = read_csv_file(test_dir / "prep_nn_tc_output.csv")
-        pd.testing.assert_frame_equal(
-            outcomes.sort_index(axis=1)
-            .sort_values(["smiles", "formula"])
-            .reset_index(drop=True),
-            true_outcomes.sort_index(axis=1)
-            .sort_values(["smiles", "formula"])
-            .reset_index(drop=True),
-        )
+    true_outcomes = read_csv_file(test_dir / "prep_nn_tc_output.csv")
+    pd.testing.assert_frame_equal(
+        outcomes.sort_index(axis=1)
+        .sort_values(["smiles", "formula"])
+        .reset_index(drop=True),
+        true_outcomes.sort_index(axis=1)
+        .sort_values(["smiles", "formula"])
+        .reset_index(drop=True),
+    )
 
 
 def test_write_nn_tc(tmp_path):
@@ -105,75 +102,68 @@ def test_write_nn_tc(tmp_path):
     plot(evaluation_type="write_nn_tc", outcome_dir=tmp_path, output_dir=tmp_path)
 
 
-def test_write_freq_distribution():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = Path(temp_dir) / "write_freq_distribution.csv"
-        outcomes = write_freq_distribution(
-            sampled_file=test_dir / "LOTUS_SMILES_processed_freq-avg_trunc.csv",
-            test_file=test_dir / "test_LOTUS_SMILES_all_trunc.smi",
-            output_file=output_file,
-        )
+def test_write_freq_distribution(tmp_path):
+    output_file = tmp_path / "write_freq_distribution.csv"
+    outcomes = write_freq_distribution(
+        sampled_file=test_dir / "LOTUS_SMILES_processed_freq-avg_trunc.csv",
+        test_file=test_dir / "test_LOTUS_SMILES_all_trunc.smi",
+        output_file=output_file,
+    )
 
-        true_outcomes = read_csv_file(test_dir / "write_freq_distribution.csv")
-        pd.testing.assert_frame_equal(outcomes, true_outcomes)
+    true_outcomes = read_csv_file(test_dir / "write_freq_distribution.csv")
+    pd.testing.assert_frame_equal(outcomes, true_outcomes)
 
-        plot(
-            evaluation_type="freq_distribution",
-            outcome_dir=temp_dir,
-            output_dir=temp_dir,
-        )
+    plot(
+        evaluation_type="freq_distribution",
+        outcome_dir=tmp_path,
+        output_dir=tmp_path,
+    )
 
 
 @pytest.mark.xfail
-def test_train_discriminator():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = Path(temp_dir) / "train_discriminator.csv"
-        outcomes = train_discriminator(
-            train_file=test_dir
-            / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",
-            sample_file=test_dir
-            / "snakemake_output/0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
-            max_mols=50000,
-            output_file=output_file,
-            seed=0,
-        )
+def test_train_discriminator(tmp_path):
+    output_file = tmp_path / "train_discriminator.csv"
+    outcomes = train_discriminator(
+        train_file=test_dir
+        / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",
+        sample_file=test_dir
+        / "snakemake_output/0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
+        max_mols=50000,
+        output_file=output_file,
+        seed=0,
+    )
 
-        true_outcomes = read_csv_file(test_dir / "train_discriminator.csv")
-        pd.testing.assert_frame_equal(outcomes, true_outcomes)
+    true_outcomes = read_csv_file(test_dir / "train_discriminator.csv")
+    pd.testing.assert_frame_equal(outcomes, true_outcomes)
 
-        plot(
-            evaluation_type="train_discriminator",
-            outcome_dir=temp_dir,
-            output_dir=temp_dir,
-        )
-
-
-def test_outcome_distr():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = Path(temp_dir) / "outcome_distr.csv"
-        outcomes = calculate_outcome_distr(
-            input_file=test_dir / "write_outcome_distr.csv",
-            output_file=output_file,
-            seed=0,
-        )
-
-        true_outcomes = read_csv_file(test_dir / "outcome_distr.csv")
-        pd.testing.assert_frame_equal(outcomes, true_outcomes)
+    plot(
+        evaluation_type="train_discriminator",
+        outcome_dir=tmp_path,
+        output_dir=tmp_path,
+    )
 
 
-def test_add_carbon():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_dir = Path(temp_dir)
-        add_carbon(
-            input_file=test_dir
-            / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",
-            output_file=output_dir / "add_carbon.csv",
-            seed=0,
-        )
+def test_outcome_distr(tmp_path):
+    output_file = tmp_path / "outcome_distr.csv"
+    outcomes = calculate_outcome_distr(
+        input_file=test_dir / "write_outcome_distr.csv",
+        output_file=output_file,
+        seed=0,
+    )
 
-        assert_checksum_equals(
-            output_dir / "add_carbon.csv", test_dir / "add_carbon.csv"
-        )
-        assert_checksum_equals(
-            output_dir / "add_carbon-unique.smi", test_dir / "add_carbon-unique.smi"
-        )
+    true_outcomes = read_csv_file(test_dir / "outcome_distr.csv")
+    pd.testing.assert_frame_equal(outcomes, true_outcomes)
+
+
+def test_add_carbon(tmp_path):
+    add_carbon(
+        input_file=test_dir
+        / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",
+        output_file=tmp_path / "add_carbon.csv",
+        seed=0,
+    )
+
+    assert_checksum_equals(tmp_path / "add_carbon.csv", test_dir / "add_carbon.csv")
+    assert_checksum_equals(
+        tmp_path / "add_carbon-unique.smi", test_dir / "add_carbon-unique.smi"
+    )

--- a/tests/test_snakemake_steps.py
+++ b/tests/test_snakemake_steps.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-import tempfile
-
 import pandas as pd
 
 from clm.commands import (
@@ -23,277 +21,260 @@ dataset = base_dir / "tests/test_data/LOTUS_truncated.txt"
 pubchem_tsv_file = base_dir / "tests/test_data/PubChem_truncated.tsv"
 
 
-def test_00_preprocess():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        preprocess.preprocess(
-            input_file=dataset,
-            output_file=temp_dir / "preprocessed.smi",
+def test_00_preprocess(tmp_path):
+    preprocess.preprocess(
+        input_file=dataset,
+        output_file=tmp_path / "preprocessed.smi",
+        max_input_smiles=1000,
+    )
+    assert_checksum_equals(
+        tmp_path / "preprocessed.smi", test_dir / "prior/raw/LOTUS_truncated.txt"
+    )
+
+
+def test_01_create_training_sets(tmp_path):
+    folds = 3
+    for fold in range(folds):
+        create_training_sets.create_training_sets(
+            input_file=test_dir / "prior/raw/LOTUS_truncated.txt",
+            train0_file=tmp_path / "train0_file_{fold}",
+            train_file=tmp_path / "train_file_{fold}",
+            vocab_file=tmp_path / "vocabulary_file_{fold}",
+            test0_file=tmp_path / "test0_file_{fold}",
+            enum_factor=0,
+            folds=folds,
+            which_fold=fold,
+            representation="SMILES",
+            min_tc=0,
+            seed=5831,
             max_input_smiles=1000,
         )
-        assert_checksum_equals(
-            temp_dir / "preprocessed.smi", test_dir / "prior/raw/LOTUS_truncated.txt"
-        )
+    # `train0_file_0` denotes the train smiles without augmentation for fold
+    # 0; Since we're running with enum_factor=0, this should be identical
+    # to `train_file_0` (train smiles with augmentation for fold 0)
+    assert_checksum_equals(tmp_path / "train0_file_0", tmp_path / "train_file_0")
+    assert_checksum_equals(
+        tmp_path / "train_file_0",
+        test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
+    )
+    assert_checksum_equals(
+        tmp_path / "vocabulary_file_0",
+        test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
+    )
+
+    # Check that the same InChI key does not appear in both the training and test set in any CV split
+    test0_all = []
+    for fold in range(folds):
+        train0 = read_csv_file(tmp_path / f"train0_file_{fold}")
+        test0 = read_csv_file(tmp_path / f"test0_file_{fold}")
+
+        train0_inchi, test0_inchi = set(train0.inchikey), set(test0.inchikey)
+        assert train0_inchi.isdisjoint(test0_inchi)
+
+        test0_all.append(test0)
+
+    # Check that there's no redundant InChI key in test sets across CV splits
+    test0_all = pd.concat(test0_all)
+    assert len(test0_all.inchikey) == len(test0_all.inchikey.unique())
 
 
-def test_01_create_training_sets():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        folds = 3
-        for fold in range(folds):
-            create_training_sets.create_training_sets(
-                input_file=test_dir / "prior/raw/LOTUS_truncated.txt",
-                train0_file=temp_dir / "train0_file_{fold}",
-                train_file=temp_dir / "train_file_{fold}",
-                vocab_file=temp_dir / "vocabulary_file_{fold}",
-                test0_file=temp_dir / "test0_file_{fold}",
-                enum_factor=0,
-                folds=folds,
-                which_fold=fold,
-                representation="SMILES",
-                min_tc=0,
-                seed=5831,
-                max_input_smiles=1000,
-            )
-        # `train0_file_0` denotes the train smiles without augmentation for fold
-        # 0; Since we're running with enum_factor=0, this should be identical
-        # to `train_file_0` (train smiles with augmentation for fold 0)
-        assert_checksum_equals(temp_dir / "train0_file_0", temp_dir / "train_file_0")
-        assert_checksum_equals(
-            temp_dir / "train_file_0",
-            test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
-        )
-        assert_checksum_equals(
-            temp_dir / "vocabulary_file_0",
-            test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
-        )
-
-        # Check that the same InChI key does not appear in both the training and test set in any CV split
-        test0_all = []
-        for fold in range(folds):
-            train0 = read_csv_file(temp_dir / f"train0_file_{fold}")
-            test0 = read_csv_file(temp_dir / f"test0_file_{fold}")
-
-            train0_inchi, test0_inchi = set(train0.inchikey), set(test0.inchikey)
-            assert train0_inchi.isdisjoint(test0_inchi)
-
-            test0_all.append(test0)
-
-        # Check that there's no redundant InChI key in test sets across CV splits
-        test0_all = pd.concat(test0_all)
-        assert len(test0_all.inchikey) == len(test0_all.inchikey.unique())
+def test_02_train_models_RNN(tmp_path):
+    inner_train_models_RNN.train_models_RNN(
+        representation="SMILES",
+        seed=0,
+        rnn_type="LSTM",
+        embedding_size=32,
+        hidden_size=256,
+        n_layers=3,
+        dropout=0,
+        batch_size=64,
+        learning_rate=0.001,
+        max_epochs=3,
+        patience=5000,
+        log_every_steps=100,
+        log_every_epochs=1,
+        sample_mols=100,
+        input_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
+        vocab_file=test_dir
+        / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
+        model_file=tmp_path / "LOTUS_truncated_SMILES_0_0_model.pt",
+        loss_file=tmp_path / "LOTUS_truncated_SMILES_0_0_loss.csv",
+        smiles_file=None,
+    )
+    # Model loss values can vary between platforms and architectures,
+    # so we simply ensure that this step runs without errors.
 
 
-def test_02_train_models_RNN():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        inner_train_models_RNN.train_models_RNN(
-            representation="SMILES",
-            seed=0,
-            rnn_type="LSTM",
-            embedding_size=32,
-            hidden_size=256,
-            n_layers=3,
-            dropout=0,
-            batch_size=64,
-            learning_rate=0.001,
-            max_epochs=3,
-            patience=5000,
-            log_every_steps=100,
-            log_every_epochs=1,
-            sample_mols=100,
-            input_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
-            vocab_file=test_dir
-            / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
-            model_file=temp_dir / "LOTUS_truncated_SMILES_0_0_model.pt",
-            loss_file=temp_dir / "LOTUS_truncated_SMILES_0_0_loss.csv",
-            smiles_file=None,
-        )
-        # Model loss values can vary between platforms and architectures,
-        # so we simply ensure that this step runs without errors.
+def test_03_sample_molecules_RNN(tmp_path):
+    output_file = tmp_path / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples.csv"
+    inner_sample_molecules_RNN.sample_molecules_RNN(
+        representation="SMILES",
+        seed=0,
+        rnn_type="LSTM",
+        embedding_size=32,
+        hidden_size=256,
+        n_layers=3,
+        dropout=0,
+        batch_size=64,
+        sample_mols=100,
+        vocab_file=test_dir
+        / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
+        model_file=test_dir / "0/prior/models/LOTUS_truncated_SMILES_0_0_model.pt",
+        output_file=output_file,
+    )
+    # Samples and their associated loss values can vary between platforms
+    # and architectures, so we simply ensure that we have the requisite number
+    # of samples
+    assert len(read_csv_file(output_file)) == 100
 
 
-def test_03_sample_molecules_RNN():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir) / "0/prior/samples"
-        inner_sample_molecules_RNN.sample_molecules_RNN(
-            representation="SMILES",
-            seed=0,
-            rnn_type="LSTM",
-            embedding_size=32,
-            hidden_size=256,
-            n_layers=3,
-            dropout=0,
-            batch_size=64,
-            sample_mols=100,
-            vocab_file=test_dir
-            / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.vocabulary",
-            model_file=test_dir / "0/prior/models/LOTUS_truncated_SMILES_0_0_model.pt",
-            output_file=temp_dir / "LOTUS_truncated_SMILES_0_0_0_samples.csv",
-        )
-        # Samples and their associated loss values can vary between platforms
-        # and architectures, so we simply ensure that this step runs without
-        # errors.
+def test_04_tabulate_molecules(tmp_path):
+    train_file = test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi"
+    output_file = (
+        tmp_path / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples_masses.csv"
+    )
+    inner_tabulate_molecules.tabulate_molecules(
+        input_file=test_dir
+        / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples.csv",
+        representation="SMILES",
+        train_file=train_file,
+        output_file=output_file,
+    )
+    assert_checksum_equals(
+        output_file,
+        test_dir / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples_masses.csv",
+    )
+    train = read_csv_file(train_file)
+    result = read_csv_file(output_file)
+
+    # Check that same InChI key does not appear in more than one row
+    assert len(result.inchikey) == len(result.inchikey.unique())
+    # None of the InChI keys in the tabulated molecules should be in the training set
+    assert set(train.inchikey).isdisjoint(set(result.inchikey))
 
 
-def test_04_tabulate_molecules():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        train_file = test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi"
-        output_file = (
-            Path(temp_dir)
-            / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples_masses.csv"
-        )
-        inner_tabulate_molecules.tabulate_molecules(
-            input_file=test_dir
-            / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples.csv",
-            representation="SMILES",
-            train_file=train_file,
-            output_file=output_file,
-        )
-        assert_checksum_equals(
-            output_file,
+def test_05_collect_tabulated_molecules(tmp_path):
+    output_file = (
+        tmp_path / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv"
+    )
+    inner_collect_tabulated_molecules.collect_tabulated_molecules(
+        input_files=[
             test_dir
             / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples_masses.csv",
-        )
-        train = read_csv_file(train_file)
-        result = read_csv_file(output_file)
+            test_dir
+            / "0/prior/samples/LOTUS_truncated_SMILES_0_1_0_samples_masses.csv",
+        ],
+        output_file=output_file,
+    )
+    assert_checksum_equals(
+        output_file,
+        test_dir / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
+    )
 
-        # Check that same InChI key does not appear in more than one row
-        assert len(result.inchikey) == len(result.inchikey.unique())
-        # None of the InChI keys in the tabulated molecules should be in the training set
-        assert set(train.inchikey).isdisjoint(set(result.inchikey))
+    result = read_csv_file(output_file)
+
+    # Check that same InChI key does not appear in more than one row
+    assert len(result.inchikey) == len(result.inchikey.unique())
 
 
-def test_05_collect_tabulated_molecules():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = (
-            Path(temp_dir)
-            / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv"
-        )
-        inner_collect_tabulated_molecules.collect_tabulated_molecules(
-            input_files=[
-                test_dir
-                / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples_masses.csv",
-                test_dir
-                / "0/prior/samples/LOTUS_truncated_SMILES_0_1_0_samples_masses.csv",
-            ],
-            output_file=output_file,
-        )
-        assert_checksum_equals(
-            output_file,
+def test_06_process_tabulated_molecules(tmp_path):
+    output_file = (
+        tmp_path / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv"
+    )
+    inner_process_tabulated_molecules.process_tabulated_molecules(
+        input_file=[
             test_dir / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
-        )
+            test_dir / "0/prior/samples/LOTUS_truncated_SMILES_1_unique_masses.csv",
+            test_dir / "0/prior/samples/LOTUS_truncated_SMILES_2_unique_masses.csv",
+        ],
+        cv_files=[
+            test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
+            test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_1.smi",
+            test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_2.smi",
+        ],
+        output_file=output_file,
+        summary_fn="freq-avg",
+    )
+    assert_checksum_equals(
+        output_file,
+        test_dir / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
+    )
 
-        result = read_csv_file(output_file)
-
-        # Check that same InChI key does not appear in more than one row
-        assert len(result.inchikey) == len(result.inchikey.unique())
-
-
-def test_06_process_tabulated_molecules():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        output_file = (
-            Path(temp_dir)
-            / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv"
-        )
-        inner_process_tabulated_molecules.process_tabulated_molecules(
-            input_file=[
-                test_dir / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
-                test_dir / "0/prior/samples/LOTUS_truncated_SMILES_1_unique_masses.csv",
-                test_dir / "0/prior/samples/LOTUS_truncated_SMILES_2_unique_masses.csv",
-            ],
-            cv_files=[
-                test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
-                test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_1.smi",
-                test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_2.smi",
-            ],
-            output_file=output_file,
-            summary_fn="freq-avg",
-        )
-        assert_checksum_equals(
-            output_file,
-            test_dir / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
-        )
-
-        result = read_csv_file(output_file)
-        # Check that same InChI key does not appear in more than one row
-        assert len(result.inchikey) == len(result.inchikey.unique())
+    result = read_csv_file(output_file)
+    # Check that same InChI key does not appear in more than one row
+    assert len(result.inchikey) == len(result.inchikey.unique())
 
 
-def test_07_write_structural_prior_CV():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir) / "0/prior/structural_prior"
-        inner_write_structural_prior_CV.write_structural_prior_CV(
-            ranks_file=temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
-            tc_file=temp_dir / "LOTUS_truncated_SMILES_0_CV_tc.csv",
-            train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
-            test_file=test_dir / "0/prior/inputs/test0_LOTUS_truncated_SMILES_0.smi",
-            pubchem_file=pubchem_tsv_file,
-            sample_file=test_dir
-            / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
-            carbon_file=test_dir
-            / "0/prior/inputs/train0_LOTUS_truncated_SMILES_0_carbon.csv",
-            err_ppm=10,
-            seed=5831,
-            chunk_size=100000,
-        )
-        assert_checksum_equals(
-            temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
-            test_dir
-            / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
-        )
-        assert_checksum_equals(
-            temp_dir / "LOTUS_truncated_SMILES_0_CV_tc.csv",
-            test_dir / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_tc.csv",
-        )
+def test_07_write_structural_prior_CV(tmp_path):
+    temp_dir = tmp_path / "0/prior/structural_prior"
+    inner_write_structural_prior_CV.write_structural_prior_CV(
+        ranks_file=temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
+        tc_file=temp_dir / "LOTUS_truncated_SMILES_0_CV_tc.csv",
+        train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
+        test_file=test_dir / "0/prior/inputs/test0_LOTUS_truncated_SMILES_0.smi",
+        pubchem_file=pubchem_tsv_file,
+        sample_file=test_dir
+        / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
+        carbon_file=test_dir
+        / "0/prior/inputs/train0_LOTUS_truncated_SMILES_0_carbon.csv",
+        err_ppm=10,
+        seed=5831,
+        chunk_size=100000,
+    )
+    assert_checksum_equals(
+        temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
+        test_dir
+        / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_ranks_structure.csv",
+    )
+    assert_checksum_equals(
+        temp_dir / "LOTUS_truncated_SMILES_0_CV_tc.csv",
+        test_dir / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_tc.csv",
+    )
 
 
-def test_08_write_formula_prior_CV():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir)
-        inner_write_formula_prior_CV.write_formula_prior_CV(
-            ranks_file=temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
-            train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
-            test_file=test_dir / "0/prior/inputs/test0_LOTUS_truncated_SMILES_0.smi",
-            pubchem_file=pubchem_tsv_file,
-            sample_file=test_dir
-            / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
-            err_ppm=10,
-            seed=5831,
-            chunk_size=100000,
-        )
-        assert_checksum_equals(
-            temp_dir / "LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
-            test_dir
-            / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
-        )
+def test_08_write_formula_prior_CV(tmp_path):
+    inner_write_formula_prior_CV.write_formula_prior_CV(
+        ranks_file=tmp_path / "LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
+        train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_0.smi",
+        test_file=test_dir / "0/prior/inputs/test0_LOTUS_truncated_SMILES_0.smi",
+        pubchem_file=pubchem_tsv_file,
+        sample_file=test_dir
+        / "0/prior/samples/LOTUS_truncated_SMILES_0_unique_masses.csv",
+        err_ppm=10,
+        seed=5831,
+        chunk_size=100000,
+    )
+    assert_checksum_equals(
+        tmp_path / "LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
+        test_dir
+        / "0/prior/structural_prior/LOTUS_truncated_SMILES_0_CV_ranks_formula.csv",
+    )
 
 
-def test_08_write_structural_prior_CV():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_dir = Path(temp_dir) / "0/prior/structural_prior/add_carbon"
-        inner_write_structural_prior_CV.write_structural_prior_CV(
-            ranks_file=temp_dir
-            / "LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
-            tc_file=temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
-            train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_all.smi",
-            test_file=test_dir / "0/prior/inputs/test_LOTUS_truncated_SMILES_all.smi",
-            pubchem_file=pubchem_tsv_file,
-            sample_file=test_dir
-            / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
-            carbon_file=test_dir
-            / "0/prior/inputs/train_LOTUS_truncated_SMILES_carbon_all.csv",
-            err_ppm=10,
-            seed=5831,
-            chunk_size=100000,
-        )
-        assert_checksum_equals(
-            temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
-            test_dir
-            / "0/prior/structural_prior/LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
-        )
-        assert_checksum_equals(
-            temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
-            test_dir
-            / "0/prior/structural_prior/LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
-        )
+def test_08_write_structural_prior_CV(tmp_path):
+    temp_dir = tmp_path / "0/prior/structural_prior/add_carbon"
+    inner_write_structural_prior_CV.write_structural_prior_CV(
+        ranks_file=temp_dir
+        / "LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
+        tc_file=temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
+        train_file=test_dir / "0/prior/inputs/train_LOTUS_truncated_SMILES_all.smi",
+        test_file=test_dir / "0/prior/inputs/test_LOTUS_truncated_SMILES_all.smi",
+        pubchem_file=pubchem_tsv_file,
+        sample_file=test_dir
+        / "0/prior/samples/LOTUS_truncated_SMILES_processed_freq-avg.csv",
+        carbon_file=test_dir
+        / "0/prior/inputs/train_LOTUS_truncated_SMILES_carbon_all.csv",
+        err_ppm=10,
+        seed=5831,
+        chunk_size=100000,
+    )
+    assert_checksum_equals(
+        temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
+        test_dir
+        / "0/prior/structural_prior/LOTUS_truncated_SMILES_all_freq-avg_CV_ranks_structure.csv",
+    )
+    assert_checksum_equals(
+        temp_dir / "LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
+        test_dir
+        / "0/prior/structural_prior/LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
+    )


### PR DESCRIPTION
Using `tmp_path` as mentioned in issue #113. In the process of adding a sanity check to `test_03_sample_molecules_RNN` I fixed a tiny undesirable behavior (the last iteration shooting past the `max_molecules` mark).

All the changes are minor (introduction of `tmp_path`), but the diff makes them appear worse. Probably `bcompare` will do a better job at highlighting these diffs.

`write_to_csv_file` with a non-dataframe was only used at one place, changed in this PR, so we can remove it in a future commit.