### PR TITLE
coverage stuff; main->master in other CI workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,16 +30,18 @@ jobs:
     - name: Install torch (CPU-only)
       run: pip3 install torch --index-url https://download.pytorch.org/whl/cpu
 
-    - name: Build source
-      run: pip install .
-
-    - name: Install developer dependencies
+    - name: Install package with extras
       run: pip install .[dev]
 
     - name: Pre-commit checks
       run: |
           pre-commit run --all-files
 
-    - name: Pytest
+    - name: Pytest with coverage
       shell: bash
-      run: pytest
+      run: coverage run --source=clm -m pytest
+
+    - name: Upload coverage to Coveralls
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [ main, vb/docs ]
+    branches: [ master ]
     tags:
       - '*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     tags:
       - '*'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ addopts = "-sv"
 [project.optional-dependencies]
 dev = [
     "build",
+    "coveralls",
     "myst-parser",
     "pre-commit",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ addopts = "-sv"
 [project.optional-dependencies]
 dev = [
     "build",
+    "coverage",
     "coveralls",
     "myst-parser",
     "pre-commit",


### PR DESCRIPTION
This setup, once merged in `master`, should cause coverage to be evaluated/reported on each PR, along with a green checkmark or a red X depending on whether coverage increased or decreased. In the latter case, the checks technically fail, so while we can still merge those PRs (we shouldn't though), this will nudge us to write tests for any new code that we add.

My guess is that this particular PR won't demonstrate any of this though, but subsequent ones will.