### PR TITLE
using csv module to parse lines in read_file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ def dataset():
 def dataset_compressed():
     path = dataset_path.with_suffix(".txt.gz")
     with gzip.open(path, "wb") as g:
+        # Add a header line so we can exercise more code paths
+        g.write("smiles\n".encode())
         with open(dataset_path, "rb") as f:
             g.write(f.read())
     yield path

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -94,7 +94,7 @@ def test_read_file_stream_compressed(dataset_compressed):
 
 def test_read_file_stream_5_compressed(dataset_compressed):
     data = read_file(
-        dataset_compressed, max_lines=5, smile_only=False, stream=True, randomize=False
+        dataset_compressed, max_lines=5, smile_only=True, stream=True, randomize=False
     )
     with pytest.raises(TypeError):
         len(data)


### PR DESCRIPTION
Fixes issue #203. We're delegating all parsing to the `csv` module now (still need a new reader for each line to support streaming like we're doing now, with minimal changes).

The `gzip` mode change from `rb` to `rt` is an orthogonal change but that reduces code complexity by a bit.