### PR TITLE
minor change to optimize tabulate molecules

### DIFF
--- a/tests/test_snakemake_steps.py
+++ b/tests/test_snakemake_steps.py
@@ -285,7 +285,6 @@ def test_08_write_structural_prior_CV(tmp_path):
 
 def test_unique_inchikeys(tmp_path):
     folds = 3
-    train0_all, train_all = [], []
     for fold in range(folds):
         create_training_sets.create_training_sets(
             input_file=test_dir / "prior/raw/LOTUS_truncated.txt",

--- a/tests/test_snakemake_steps.py
+++ b/tests/test_snakemake_steps.py
@@ -281,3 +281,35 @@ def test_08_write_structural_prior_CV(tmp_path):
         test_dir
         / "0/prior/structural_prior/LOTUS_truncated_SMILES_all_freq-avg_CV_tc.csv",
     )
+
+
+def test_unique_inchikeys(tmp_path):
+    folds = 3
+    train0_all, train_all = [], []
+    for fold in range(folds):
+        create_training_sets.create_training_sets(
+            input_file=test_dir / "prior/raw/LOTUS_truncated.txt",
+            train0_file=tmp_path / "train0_file_{fold}",
+            train_file=tmp_path / "train_file_{fold}",
+            vocab_file=tmp_path / "vocabulary_file_{fold}",
+            test0_file=tmp_path / "test0_file_{fold}",
+            enum_factor=3,
+            folds=folds,
+            which_fold=fold,
+            representation="SMILES",
+            min_tc=0,
+            seed=5831,
+            max_input_smiles=1000,
+        )
+
+        train0_inchi = read_csv_file(tmp_path / f"train0_file_{fold}")["inchikey"]
+        train_inchi = read_csv_file(tmp_path / f"train_file_{fold}")["inchikey"]
+
+        # Verifying that both augmented and un-augmented training set has same unique inchikeys
+        assert set(train_inchi) == set(train0_inchi)
+
+        train_all.extend(train_inchi.to_list())
+        train0_all.extend(train0_inchi.to_list())
+
+    # Verifying that both augmented and un-augmented training set has same unique inchikeys across the fold
+    assert set(train_all) == set(train0_all)

--- a/tests/test_snakemake_steps.py
+++ b/tests/test_snakemake_steps.py
@@ -307,9 +307,3 @@ def test_unique_inchikeys(tmp_path):
 
         # Verifying that both augmented and un-augmented training set has same unique inchikeys
         assert set(train_inchi) == set(train0_inchi)
-
-        train_all.extend(train_inchi.to_list())
-        train0_all.extend(train0_inchi.to_list())
-
-    # Verifying that both augmented and un-augmented training set has same unique inchikeys across the fold
-    assert set(train_all) == set(train0_all)

--- a/workflow/Snakefile_data
+++ b/workflow/Snakefile_data
@@ -229,7 +229,7 @@ rule tabulate_molecules:
     conda: "clm"
     input:
         input_file = PATHS['input_file'],
-        train_file = PATHS['train_file']
+        train_file = PATHS['train0_file']
     output:
         output_file=PATHS['tabulate_molecules_output'],
         known_smiles_file = PATHS['known_smiles_file'],


### PR DESCRIPTION
Keeping track of frequencies of each invalid and known SMILES as we iterate instead of using `list.count()` at the end. I ran this step for the first time after incorporating `invalid` and `known` SMILES, and this step took almost a day to complete. The change in this PR sped up the process by orders of magnitudes. 

Also, updated input train file for `tabulate_molecules` to be un-augmented train file (`train0`). Since we're only comparing inchikeys at this step and augmented as well as un-augmented dataset have same unique inchikeys, using un-augmented train here will be much faster. 