### PR TITLE
Vb/docs start

### DIFF
--- a/docs/clm/faq.md
+++ b/docs/clm/faq.md
@@ -1,0 +1,12 @@
+# Frequently Asked Questions
+
+- [How do I get sample datasets for CLM use?](#datasets-for-clm)
+- [What is the PubChem dataset and why do I need it?](#what-is-pubchem)
+
+## How do I get sample datasets for CLM use?
+
+Answer here
+
+## What is the PubChem dataset and why do I need it?
+
+Answer here

--- a/docs/clm/installation.md
+++ b/docs/clm/installation.md
@@ -1,0 +1,7 @@
+## Installation
+
+To install `clm`:
+
+```
+conda ..
+```

--- a/docs/clm/installation.md
+++ b/docs/clm/installation.md
@@ -5,3 +5,5 @@ To install `clm`:
 ```
 conda ..
 ```
+
+Also see [Frequently Asked Questions](faq.md)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ author = "Michael Skinnider, Anushka Acharya, Vineet Bansal"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinxcontrib.bibtex", "sphinx.ext.autodoc"]
+extensions = ["sphinxcontrib.bibtex", "sphinx.ext.autodoc", "myst_parser"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ as used in the manuscript, :cite:t:`Skinnider2021`.
 .. toctree::
 
    clm/installation.md
+   clm/faq.md
 
 .. toctree::
    :titlesonly:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,10 @@ A package to train and evaluate deep generative models of novel psychoactive sub
 as used in the manuscript, :cite:t:`Skinnider2021`.
 
 .. toctree::
+
+   clm/installation.md
+
+.. toctree::
    :titlesonly:
 
    modules


### PR DESCRIPTION
Sample pages for docs.

The README can have generally useful stuff like you're trying to add here. The `docs/` is a more permanent location for these kind of targeted documentation on installation/workflow/faq etc. Let's start with tweaking the `installation.md` page to have the stuff that you've written here for installation. There's bound to be some overlap, with the `docs/` being a more verbose and elaborate version of the README