### PR TITLE
Potential bug fixes with plots for nn_tc_ever_v_never/structural_prior_min_freq

### DIFF
--- a/src/clm/plot/nn_tc_ever_v_never.py
+++ b/src/clm/plot/nn_tc_ever_v_never.py
@@ -69,8 +69,16 @@ def plot_generated_ratio(ranks_file, output_dir):
     # Overall rank file
     rank_df = read_csv_file(ranks_file)
     data = {
-        "Ever Generated": len(rank_df[rank_df["target_rank"].notnull()]),
-        "Never Generated": len(rank_df[rank_df["target_rank"].isnull()]),
+        "Ever Generated": len(
+            rank_df[rank_df["target_source"] == "model"][
+                rank_df["target_rank"].notnull()
+            ]
+        ),
+        "Never Generated": len(
+            rank_df[rank_df["target_source"] == "model"][
+                rank_df["target_rank"].isnull()
+            ]
+        ),
     }
 
     sns.set_style("darkgrid")

--- a/src/clm/plot/structural_prior_min_freq.py
+++ b/src/clm/plot/structural_prior_min_freq.py
@@ -48,6 +48,7 @@ def plot_topk(min_freqs, rank_files, output_dir):
             read_csv_file(filename, delimiter=",", index_col=0).assign(min_freqs=freq)
         )
     outcomes = pd.concat(outcomes)
+    outcomes = outcomes[outcomes["target_source"] == "model"]
 
     topk(
         outcomes,
@@ -115,6 +116,7 @@ def plot_p_ever_generated(
 
     for filename, freq in zip(rank_files, min_freqs.keys()):
         outcome = read_csv_file(filename, delimiter=",")
+        outcome = outcome[outcome["target_source"] == "model"]
         ever_generated = outcome[outcome["target_rank"].notnull()]
         min_freqs[freq] = round((len(ever_generated) / len(outcome)) * 100, 2)
 


### PR DESCRIPTION
It looks to me like the plots meant to be generated by `nn_tc_ever_v_never` and `structural_prior_min_freq` are purported to only look at target ranks for the generative model, not others (pubchem/addcarbon etc), so I've incorporated those filters here. 

The change in plots for `PED` dataset (enum factor `100`) are:

## Before

![ratio_ever_v_never](https://github.com/skinniderlab/CLM/assets/318858/43da1217-de65-4335-a1c8-fdd880595c19)
![p_ever_generated](https://github.com/skinniderlab/CLM/assets/318858/ba13dac8-f999-4ded-ba52-b181196402ef)
![top_k_min_freq](https://github.com/skinniderlab/CLM/assets/318858/cde3de07-0c3c-49d9-9fef-b3cc197eb46f)

## After
![ratio_ever_v_never](https://github.com/skinniderlab/CLM/assets/318858/bbecf030-46f1-4b5d-8d67-59d8716669dd)
![top_k_min_freq](https://github.com/skinniderlab/CLM/assets/318858/ef94e4ae-869b-4a9e-aed3-0454b3399965)
![p_ever_generated](https://github.com/skinniderlab/CLM/assets/318858/04b08280-bc7c-4927-9ae6-9eca051ec68f)
