### PR TITLE
setting seed in a fixture at the function level

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import gzip
 import pytest
+from clm.functions import set_seed
 
 base_dir = Path(__file__).parent.parent
 dataset_path = base_dir / "tests/test_data/LOTUS_truncated.txt"
@@ -20,3 +21,12 @@ def dataset_compressed():
         with open(dataset_path, "rb") as f:
             g.write(f.read())
     yield path
+
+
+@pytest.fixture(scope="function", autouse=True)
+def seed():
+    """
+    Set the random seed to 0 for all tests.
+    This prevents individual tests that use set_seed from affecting each other.
+    """
+    set_seed(0)

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -127,7 +127,6 @@ def test_write_nn_tc(tmp_path):
     query_file = test_dir / "input_write_nn_tc_query_file.csv"
     reference_file = test_dir / "input_write_nn_tc_reference_file.csv"
     output_file = tmp_path / "output_write_nn_tc.csv"
-    set_seed(0)
     outcomes = write_nn_Tc(
         query_file=query_file,
         reference_file=reference_file,
@@ -167,7 +166,6 @@ def test_write_freq_distribution(tmp_path):
 
 def test_train_discriminator(tmp_path):
     output_file = tmp_path / "train_discriminator.csv"
-    set_seed(0)
     outcomes = train_discriminator(
         train_file=test_dir
         / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",
@@ -222,7 +220,6 @@ def test_outcome_distr(tmp_path):
 
 
 def test_add_carbon(tmp_path):
-    set_seed(0)
     add_carbon(
         input_file=test_dir
         / "snakemake_output/0/prior/inputs/train0_LOTUS_truncated_SMILES_0.smi",

--- a/tests/test_snakemake_steps.py
+++ b/tests/test_snakemake_steps.py
@@ -80,7 +80,6 @@ def test_01_create_training_sets(tmp_path):
 
 
 def test_02_train_models_RNN(tmp_path):
-    set_seed(0)
     train_models_RNN.train_models_RNN(
         representation="SMILES",
         rnn_type="LSTM",
@@ -108,7 +107,6 @@ def test_02_train_models_RNN(tmp_path):
 
 def test_03_sample_molecules_RNN(tmp_path):
     output_file = tmp_path / "0/prior/samples/LOTUS_truncated_SMILES_0_0_0_samples.csv"
-    set_seed(0)
     sample_molecules_RNN.sample_molecules_RNN(
         representation="SMILES",
         rnn_type="LSTM",


### PR DESCRIPTION
Implemented a fixture that is called automatically before each test function call, which sets the random seed using our `set_seed` function.

This is not just a convenience such that we don't have to use `set_seed(0)` in individual test functions, though I'm also leveraging that in this PR, but is also important to make sure that one test function using `set_seed` doesn't affect other test functions' behavior (since all test functions run in the same process).

Currently any tests that use `set_seed` will affect the behavior of any tests that come after it and don't use a `set_seed`, which makes it impossible to reorder tests, introduce new tests, delete tests etc without behavior being affected across the board in unpredictable ways.

Individual tests can still use `set_seed` (like in the several cases of `set_seed(5831)` that I see in the code) if they want to.