### PR TITLE
Getting paths from config whenever we can

### DIFF
--- a/src/clm/functions.py
+++ b/src/clm/functions.py
@@ -504,7 +504,6 @@ def write_to_csv_file(
             compression=compression,
         )
     else:
-        logger.warning("Non-DataFrame input support will be removed soon")
         assert compression in (None, "gzip"), "Invalid compression type"
         if compression == "gzip":
             mode = "wb" if mode == "w" else "ab"  # binary mode for gzip

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -62,12 +62,12 @@ rule calculate_outcomes:
     """
     conda: "clm"
     input:
-        sampled_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        known_smiles=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/known_{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        invalid_smiles=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/invalid_{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        train_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train0_{{dataset}}_{{repr}}_{{fold}}.smi",
+        sampled_file=config['paths']['collect_tabulated_output'],
+        known_smiles=config['paths']['collect_known_smiles'],
+        invalid_smiles=config['paths']['collect_invalid_smiles'],
+        train_file=config['paths']['train0_file'],
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcomes.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcomes.csv.gz",
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -101,11 +101,11 @@ rule plot_calculate_outcomes:
 rule write_nn_tc:
     conda: "clm"
     input:
-        query_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        reference_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train0_{{dataset}}_{{repr}}_{{fold}}.smi",
+        query_file=config['paths']['collect_tabulated_output'],
+        reference_file=config['paths']['train0_file'],
         pubchem_file=PATHS['pubchem_tsv_file'],
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_write_nn_tc.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_write_nn_tc.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -138,10 +138,10 @@ rule plot_write_nn_tc:
 rule train_discriminator:
     conda: "clm"
     input:
-        train_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train0_{{dataset}}_{{repr}}_{{fold}}.smi",
-        sampled_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
+        train_file=config['paths']['train0_file'],
+        sampled_file=config['paths']['collect_tabulated_output']
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_train_discriminator.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_train_discriminator.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -172,10 +172,10 @@ rule plot_train_discriminator:
 rule freq_distribution:
     conda: "clm"
     input:
-        sampled_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        test_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/test0_{{dataset}}_{{repr}}_{{fold}}.smi",
+        sampled_file=config['paths']['collect_tabulated_output'],
+        test_file=config['paths']['test0_file'],
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_freq_distribution.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_freq_distribution.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -205,11 +205,11 @@ rule plot_freq_distribution:
 rule calculate_outcome_distrs:
     conda: "clm"
     input:
-        sample_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_{{fold}}_unique_masses.csv.gz",
-        train_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train0_{{dataset}}_{{repr}}_{{fold}}.smi",
+        sample_file=config['paths']['collect_tabulated_output'],
+        train_file=config['paths']['train0_file'],
         pubchem_file=PATHS['pubchem_tsv_file'],
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcome_distrs.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcome_distrs.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -241,10 +241,10 @@ rule plot_outcome_distributions:
 rule nn_tc_ever_v_never:
     conda: "clm"
     input:
-        query_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/test0_{{dataset}}_{{repr}}_{{fold}}.smi",
-        reference_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/train0_{{dataset}}_{{repr}}_{{fold}}.smi",
+        query_file=config['paths']['test0_file'],
+        reference_file=config['paths']['train0_file']
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_nn_tc_ever_v_never.csv.gz",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_nn_tc_ever_v_never.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -261,12 +261,12 @@ rule plot_nn_tc_ever_v_never:
     input:
         nn_tc_file = expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_nn_tc_ever_v_never.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True),
-        rank_files = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_{{fold}}_CV_ranks_structure.csv.gz",
+        rank_files = expand(config['paths']['cv_ranks_file'],
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True),
-        ranks_file = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min1_all_freq-avg_CV_ranks_structure.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True),
+        ranks_file = expand(config['paths']['overall_ranks_file'],
+            min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True),
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/nn_tc_ever_v_never"),
+        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/nn_tc_ever_v_never"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -280,10 +280,10 @@ rule plot_nn_tc_ever_v_never:
 rule plot_topk_tc:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min1_all_freq-avg_CV_tc.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
+        expand(config['paths']['overall_tc_file'],
+            min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/topk_tc"),
+        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/topk_tc"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -296,11 +296,11 @@ rule plot_topk_tc:
 rule forecast:
     conda: "clm"
     input:
-        test_file=f"{OUTPUT_DIR}/{{enum_factor}}/prior/inputs/test_{{dataset}}_{{repr}}_all.smi",
-        sample_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/samples/{{dataset}}_{{repr}}_processed_min1_freq-avg.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
+        test_file=config['paths']['test_all_file'],
+        sample_file=expand(config['paths']['process_tabulated_output'],
+            min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        output_file=f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_forecast.csv",
+        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_forecast.csv",
     resources:
         mem_mb=64000,
         runtime=30,
@@ -331,12 +331,12 @@ rule plot_forecast:
 rule plot_topk:
     conda: "clm"
     input:
-        rank_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min1_all_freq-avg_CV_ranks_structure.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True),
-        tc_file=expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min1_all_freq-avg_CV_tc.csv.gz",
-        dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
+        rank_file=expand(config['paths']['overall_ranks_file'],
+            min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True),
+        tc_file=expand(config['paths']['overall_tc_file'],
+        min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/topk"),
+        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/topk"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -349,12 +349,12 @@ rule plot_topk:
 
 rule plot_structural_prior_min_freq:
     input:
-        rank_files = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min{{min_freq}}_all_freq-avg_CV_ranks_structure.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, min_freq=MIN_FREQS, allow_missing=True),
-        tc_files = expand(f"{OUTPUT_DIR}/{{enum_factor}}/prior/structural_prior/{{dataset}}_{{repr}}_min{{min_freq}}_all_freq-avg_CV_tc.csv.gz",
-            dataset=DATASET, repr=REPRESENTATIONS, min_freq=MIN_FREQS, allow_missing=True)
+        rank_files = expand(config['paths']['overall_ranks_file'],
+            metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, min_freq=MIN_FREQS, allow_missing=True),
+        tc_files = expand(config['paths']['overall_tc_file'],
+            metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, min_freq=MIN_FREQS, allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/structural_prior_min_freq")
+        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/structural_prior_min_freq")
     resources:
         mem_mb=64000,
         runtime=30,

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -67,7 +67,7 @@ rule calculate_outcomes:
         invalid_smiles=config['paths']['collect_invalid_smiles'],
         train_file=config['paths']['train0_file'],
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcomes.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_calculate_outcomes.csv.gz",
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -85,10 +85,10 @@ rule calculate_outcomes:
 rule plot_calculate_outcomes:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcomes.csv.gz",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_calculate_outcomes.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/calculate_outcomes"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/calculate_outcomes"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -105,7 +105,7 @@ rule write_nn_tc:
         reference_file=config['paths']['train0_file'],
         pubchem_file=PATHS['pubchem_tsv_file'],
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_write_nn_tc.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_write_nn_tc.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -121,10 +121,10 @@ rule write_nn_tc:
 rule plot_write_nn_tc:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_write_nn_tc.csv.gz",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_write_nn_tc.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/write_nn_tc"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/write_nn_tc"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -141,7 +141,7 @@ rule train_discriminator:
         train_file=config['paths']['train0_file'],
         sampled_file=config['paths']['collect_tabulated_output']
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_train_discriminator.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_train_discriminator.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -156,10 +156,10 @@ rule train_discriminator:
 rule plot_train_discriminator:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_train_discriminator.csv.gz",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_train_discriminator.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/train_discriminator"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/train_discriminator"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -175,7 +175,7 @@ rule freq_distribution:
         sampled_file=config['paths']['collect_tabulated_output'],
         test_file=config['paths']['test0_file'],
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_freq_distribution.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_freq_distribution.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -189,10 +189,10 @@ rule freq_distribution:
 rule plot_freq_distribution:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_freq_distribution.csv.gz",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_freq_distribution.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/freq_distribution"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/freq_distribution"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -209,7 +209,7 @@ rule calculate_outcome_distrs:
         train_file=config['paths']['train0_file'],
         pubchem_file=PATHS['pubchem_tsv_file'],
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcome_distrs.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_calculate_outcome_distrs.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -226,10 +226,10 @@ rule calculate_outcome_distrs:
 rule plot_outcome_distributions:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_calculate_outcome_distrs.csv.gz",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_calculate_outcome_distrs.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/calculate_outcome_distrs"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/calculate_outcome_distrs"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -244,7 +244,7 @@ rule nn_tc_ever_v_never:
         query_file=config['paths']['test0_file'],
         reference_file=config['paths']['train0_file']
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_nn_tc_ever_v_never.csv.gz",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_nn_tc_ever_v_never.csv.gz",
     resources:
         mem_mb=64000,
         runtime=1000,
@@ -259,14 +259,14 @@ rule nn_tc_ever_v_never:
 rule plot_nn_tc_ever_v_never:
     conda: "clm"
     input:
-        nn_tc_file = expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_{{fold}}_nn_tc_ever_v_never.csv.gz",
+        nn_tc_file = expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_{fold}_nn_tc_ever_v_never.csv.gz",
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True),
         rank_files = expand(config['paths']['cv_ranks_file'],
             dataset=DATASET, repr=REPRESENTATIONS, fold=range(FOLDS), allow_missing=True),
         ranks_file = expand(config['paths']['overall_ranks_file'],
             min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True),
     output:
-        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/nn_tc_ever_v_never"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/nn_tc_ever_v_never"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -283,7 +283,7 @@ rule plot_topk_tc:
         expand(config['paths']['overall_tc_file'],
             min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/topk_tc"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/topk_tc"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -300,7 +300,7 @@ rule forecast:
         sample_file=expand(config['paths']['process_tabulated_output'],
             min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        output_file=f"{{output_dir}}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_forecast.csv",
+        output_file="{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_forecast.csv",
     resources:
         mem_mb=64000,
         runtime=30,
@@ -315,10 +315,10 @@ rule forecast:
 rule plot_forecast:
     conda: "clm"
     input:
-        expand(f"{OUTPUT_DIR}/model_evaluation/{{enum_factor}}/{{dataset}}_{{repr}}_forecast.csv",
+        expand("{output_dir}/model_evaluation/{enum_factor}/{dataset}_{repr}_forecast.csv",
             dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        directory(f"{OUTPUT_DIR}/model_evaluation/plot/{{enum_factor}}/forecast"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/forecast"),
     resources:
         mem_mb=64000,
         runtime=30,
@@ -336,7 +336,7 @@ rule plot_topk:
         tc_file=expand(config['paths']['overall_tc_file'],
         min_freq=1, metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, allow_missing=True)
     output:
-        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/topk"),
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/topk"),
     resources:
         mem_mb=256000,
         runtime=1000,
@@ -354,7 +354,7 @@ rule plot_structural_prior_min_freq:
         tc_files = expand(config['paths']['overall_tc_file'],
             metric='freq-avg', dataset=DATASET, repr=REPRESENTATIONS, min_freq=MIN_FREQS, allow_missing=True)
     output:
-        directory(f"{{output_dir}}/model_evaluation/plot/{{enum_factor}}/structural_prior_min_freq")
+        directory("{output_dir}/model_evaluation/plot/{enum_factor}/structural_prior_min_freq")
     resources:
         mem_mb=64000,
         runtime=30,

--- a/workflow/Snakefile_data
+++ b/workflow/Snakefile_data
@@ -76,7 +76,7 @@ rule create_training_sets:
     """
     conda: "clm"
     input:
-        "{output_dir}/prior/raw/{dataset}.txt"
+        config['paths']['preprocess_output']
     output:
         train_file = PATHS['train_file'],
         vocab_file = PATHS['vocab_file'],

--- a/workflow/config/config.yaml
+++ b/workflow/config/config.yaml
@@ -48,9 +48,12 @@ structural_prior_min_freq:
   - 4
 random_seed: 5831
 paths:
+  # Modify these paths to match your system
   output_dir: data
   dataset: "../tests/test_data/LOTUS_truncated.txt"
   pubchem_tsv_file: "../tests/test_data/PubChem_truncated.tsv"
+
+  # The following paths can be modified, as long as all wildcards are preserved in each case
   preprocess_output: "{output_dir}/prior/raw/{dataset}.txt"
   train_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_{fold}.smi"
   vocab_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_{fold}.vocabulary"
@@ -58,7 +61,6 @@ paths:
   input_file: "{output_dir}/{enum_factor}/prior/samples/{dataset}_{repr}_{fold}_{train_seed}_{sample_seed}_samples.csv.gz"
   train0_file: "{output_dir}/{enum_factor}/prior/inputs/train0_{dataset}_{repr}_{fold}.smi"
   test0_file: "{output_dir}/{enum_factor}/prior/inputs/test0_{dataset}_{repr}_{fold}.smi"
-  sample_file: "{output_dir}/{enum_factor}/prior/samples/{dataset}_{repr}_{fold}_unique_masses.csv.gz"
   carbon_file: "{output_dir}/{enum_factor}/prior/inputs/train0_{dataset}_{repr}_{fold}_carbon.csv.gz"
   train_all_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_all.smi"
   test_all_file: "{output_dir}/{enum_factor}/prior/inputs/test_{dataset}_{repr}_all.smi"

--- a/workflow/config/config_fast.yaml
+++ b/workflow/config/config_fast.yaml
@@ -31,9 +31,12 @@ structural_prior_min_freq:
   - 1
 random_seed: 5831
 paths:
+  # Modify these paths to match your system
   output_dir: data
   dataset: "../tests/test_data/LOTUS_truncated.txt"
   pubchem_tsv_file: "../tests/test_data/PubChem_truncated.tsv"
+
+  # The following paths can be modified, as long as all wildcards are preserved in each case
   preprocess_output: "{output_dir}/prior/raw/{dataset}.txt"
   train_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_{fold}.smi"
   vocab_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_{fold}.vocabulary"
@@ -41,7 +44,6 @@ paths:
   input_file: "{output_dir}/{enum_factor}/prior/samples/{dataset}_{repr}_{fold}_{train_seed}_{sample_seed}_samples.csv.gz"
   train0_file: "{output_dir}/{enum_factor}/prior/inputs/train0_{dataset}_{repr}_{fold}.smi"
   test0_file: "{output_dir}/{enum_factor}/prior/inputs/test0_{dataset}_{repr}_{fold}.smi"
-  sample_file: "{output_dir}/{enum_factor}/prior/samples/{dataset}_{repr}_{fold}_unique_masses.csv.gz"
   carbon_file: "{output_dir}/{enum_factor}/prior/inputs/train0_{dataset}_{repr}_{fold}_carbon.csv.gz"
   train_all_file: "{output_dir}/{enum_factor}/prior/inputs/train_{dataset}_{repr}_all.smi"
   test_all_file: "{output_dir}/{enum_factor}/prior/inputs/test_{dataset}_{repr}_all.smi"


### PR DESCRIPTION
Addressing issue #228 - `Snakefile` and `Snakefile_data` have been modified to get paths from the configuration file, whenever they can.

As discussed in issue #228 - we cannot remove any wildcards from any of these paths without also tweaking the rules themselves, but we can always rearrange them as we see fit. I've tested this out by inserting random path components at random places in each of the paths, and it gets picked up by `snakemake` (and the tests pass).

Note that this does not mean that there aren't paths that haven't (yet) been exposed in the `config` file - all of these are in `Snakemake` for model evaluation purposes (in the `model_evaluation` folder relative to `output_dir`). These can be pulled out into the `config` file at some point if needed, but perhaps we can add another issue on that.

`sample_file` in the config files was never used, so I've removed that. Also disabled an annoying warning for now since that overwhelms stdout.