### PR TITLE
Resolving second part of Issue 256

### DIFF
--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -177,7 +177,7 @@ def calculate_outcomes_dataframe(sample_df, train_df):
         n_total_smiles = df["size"].sum()
 
         # Filtering out invalid smiles
-        bin_df = df[df["is_valid"]]
+        bin_df = df[~df["canonical_smiles"].isnull()]
 
         n_valid_smiles = bin_df["size"].sum()
 

--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -177,7 +177,7 @@ def calculate_outcomes_dataframe(sample_df, train_df):
         n_total_smiles = df["size"].sum()
 
         # Filtering out invalid smiles
-        bin_df = df[~df["canonical_smiles"].isnull()]
+        bin_df = df[~df["canonical_smile"].isnull()]
 
         n_valid_smiles = bin_df["size"].sum()
 


### PR DESCRIPTION
It appears that when the `clean_mol` function returns `None`, we fail to recognize the corresponding SMILES string as invalid. As a result, the downstream analysis proceeds with computations on this invalid input.

The changes in this pull request checks the validity of SMILES based on nullity of `canonical_smiles`. Instead of using `bin_df = df[df["is_valid"]]`, we are filtering valid smiles from the DataFrame with something like `df[~df['canonical_smiles'].isnull()]` in line 180.