### PR TITLE
Treating warnings as errors

### DIFF
--- a/.github/workflows/tests_no_warnings.yml
+++ b/.github/workflows/tests_no_warnings.yml
@@ -1,0 +1,63 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  build_and_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10"]
+
+    name: Build and test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # Required when using an activated conda environment in steps
+        # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT
+        shell: bash -l {0}
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Set up conda environment
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        activate-environment: clm
+        environment-file: environment.yml
+
+    - name: Install pip
+      run: conda install pip
+
+    - name: Install torch (CPU-only)
+      run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+    - name: Install package
+      run: pip install -e .
+
+    - name: Conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Pre-commit checks
+      run: |
+          pre-commit run --all-files
+
+    - name: Pytest with coverage (warnings as errors)
+      run: coverage run --source=src/clm -m pytest
+      env:
+        PYTHONWARNINGS: error
+
+    - name: Upload coverage to Coveralls
+      if: matrix.os == 'ubuntu-latest'
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
@anushka255 - I'm seeing a lot of warnings on running the snakemake pipeline, primarily from `pandas`. While these are not critical now, they will turn into hard-to-debug errors in the future (e.g. `SettingWithCopyWarning`) when `pandas` changes its behavior in some future version. The Aspire project, for example, decided to totally get rid of `pandas` because they couldn't handle the regular API behavior changes from them.

This PR treats all warnings as errors when running the tests, and should serve as a base PR to ensure we've weeded out all warnings. We can handle these gradually of course.

Trying to catch all warnings instead of only the ones from `pandas` might seem like an overkill, but I think the warnings originate from a handful of lines (unclosed files in tests, other changes like `np.random.shuffle(<series>) -> <series>.sample(frac=1)`), so it should be manageable. If this turns into a never ending exercise then we can restrict ourselves to `pandas`.