### PR TITLE
A minor tweak to the code change in PR 258

### DIFF
--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -177,7 +177,9 @@ def calculate_outcomes_dataframe(sample_df, train_df):
         n_total_smiles = df["size"].sum()
 
         # Filtering out invalid smiles
-        bin_df = df[~df["canonical_smile"].isnull()]
+        bin_df = df[df["is_valid"]]
+        if "canonical_smile" in df.columns:
+            bin_df = df[~df["canonical_smile"].isnull()]
 
         n_valid_smiles = bin_df["size"].sum()
 


### PR DESCRIPTION
PR 258 changed `calculate_outcomes.py` at one point to go from:
```
bin_df = df[df["is_valid"]]
```
to
```
bin_df = df[~df["canonical_smile"].isnull()]
```
 
This assumes that `canonical_smile` column is always present in the input Dataframe. As it turns out, this is not always true - this column is never added if `df` had 0 rows to begin with, so this new code causes an exception where none would have been raised before.

Simply replacing the original code by
```
if "canonical_smile" in df.columns: 
    bin_df = df[~df["canonical_smile"].isnull()]  
```

is not sufficient either, since we *do* want to filter the incoming Dataframe base on the `is_valid` column.

What we intended to do here was to let the original code do what it would have done, and *in addition* also watch out for the case if `canonical_smile` (if present), being not null.