### PR TITLE
insert try,except for smile_properties_dataframe

### DIFF
--- a/src/clm/commands/calculate_outcomes.py
+++ b/src/clm/commands/calculate_outcomes.py
@@ -101,7 +101,10 @@ molecular_properties = {
 def smile_properties_dataframe(a_row, is_sample=False):
     data = []
     if (mol := clean_mol(a_row.smiles, raise_error=False)) is not None:
-        row = tuple(fun(mol) for fun in molecular_properties.values())
+        try:
+            row = tuple(fun(mol) for fun in molecular_properties.values())
+        except Exception:
+            row = tuple([None] * len(molecular_properties))
     else:
         row = tuple([None] * len(molecular_properties))
 


### PR DESCRIPTION
I got this error in two folds of a 5 fold trained model where the "Explicit valence for atom # N C greater than permitted,"
the merge contains the following try/except code used to bypass this although not sure if this is appropriate for a permanent solution.

```
Traceback (most recent call last):
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/bin/clm", line 8, in <module>
    sys.exit(main())
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/__main__.py", line 81, in main
    args.func(args)
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 356, in main
    calculate_outcomes(
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 343, in calculate_outcomes
    train_df, sample_df = get_dataframes(train_file, prep_sample_df)
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 157, in get_dataframes
    valid_data = prep_sample_df[prep_sample_df["is_valid"]].progress_apply(
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/tqdm/std.py", line 917, in inner
    return getattr(df, df_function)(wrapper, **kwargs)
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/pandas/core/frame.py", line 10374, in apply
    return op.apply().__finalize__(self, method="apply")
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/pandas/core/apply.py", line 916, in apply
    return self.apply_standard()
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/pandas/core/apply.py", line 1063, in apply_standard
    results, res_index = self.apply_series_generator()
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/pandas/core/apply.py", line 1081, in apply_series_generator
    results[i] = self.func(v, *self.args, **self.kwargs)
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/tqdm/std.py", line 912, in wrapper
    return func(*args, **kwargs)
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 158, in <lambda>
    lambda x: smile_properties_dataframe(x, is_sample=True), axis=1
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 104, in smile_properties_dataframe
    row = tuple(fun(mol) for fun in molecular_properties.values())
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 104, in <genexpr>
    row = tuple(fun(mol) for fun in molecular_properties.values())
  File "/Genomics/skinniderlab/spavelites/git/CLM/src/clm/commands/calculate_outcomes.py", line 94, in <lambda>
    "murcko": lambda mol: MurckoScaffoldSmiles(mol=mol),
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/rdkit/Chem/Scaffolds/MurckoScaffold.py", line 116, in MurckoScaffoldSmiles
    scaffold = GetScaffoldForMol(mol)
  File "/Genomics/skinniderlab/spavelites/.conda/envs/clm/lib/python3.10/site-packages/rdkit/Chem/Scaffolds/MurckoScaffold.py", line 80, in GetScaffoldForMol
    res.UpdatePropertyCache()
rdkit.Chem.rdchem.AtomValenceException: Explicit valence for atom # 5 C greater than permitted
[Wed Feb 26 06:26:21 2025]
Error in rule calculate_outcomes:
    jobid: 0
    input: /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/known_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/invalid_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/inputs/train0_PED_NOT_PED_equal_SMILES_1.smi
    output: /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/model_evaluation/100/PED_NOT_PED_equal_SMILES_1_calculate_outcomes.csv.gz
    shell:
        clm calculate_outcomes --train_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/inputs/train0_PED_NOT_PED_equal_SMILES_1.smi --sampled_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --known_smiles_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/known_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --invalid_smiles_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/invalid_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --max_molecules 500000 --seed 12 --output_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/model_evaluation/100/PED_NOT_PED_equal_SMILES_1_calculate_outcomes.csv.gz 
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
srun: error: argo-59: task 0: Exited with exit code 1
srun: launch/slurm: _step_signal: Terminating StepId=7795192.0
[Wed Feb 26 06:26:21 2025]
Error in rule calculate_outcomes:
    jobid: 0
    input: /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/known_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/invalid_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz, /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/inputs/train0_PED_NOT_PED_equal_SMILES_1.smi
    output: /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/model_evaluation/100/PED_NOT_PED_equal_SMILES_1_calculate_outcomes.csv.gz
    shell:
        clm calculate_outcomes --train_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/inputs/train0_PED_NOT_PED_equal_SMILES_1.smi --sampled_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --known_smiles_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/known_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --invalid_smiles_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/100/prior/samples/invalid_PED_NOT_PED_equal_SMILES_1_unique_masses.csv.gz --max_molecules 500000 --seed 12 --output_file /Genomics/skinniderlab/spavelites/git/PED-generation/outputs/2025-02-25/equal/model_evaluation/100/PED_NOT_PED_equal_SMILES_1_calculate_outcomes.csv.gz 
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
```