### PR TITLE
fix typo

### DIFF
--- a/workflow/Snakefile_data
+++ b/workflow/Snakefile_data
@@ -68,7 +68,7 @@ rule preprocess:
         '--valid-atoms {config[preprocess][valid_atoms]} '
         '--max-input-smiles {config[max_input_smiles]} '
         f'{"--keep_duplicates" if config["preprocess"]["keep_duplicates"] else ""}'
-        f'{"--no_neutralise " if not config["preprocess"]["neutralise"] else ""} '
+        f'{"--no-neutralise " if not config["preprocess"]["neutralise"] else ""} '
         f'{"--remove-rare " if config["preprocess"]["remove_rare"] else ""} '
 
 


### PR DESCRIPTION
Fixes the error message below, obtained because Snakefile used `--no_neutralise` whereas preprocess.py argparse expects `--no-neutralise`. 

```
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Provided resources: mem_mb=12000, mem_mib=11445, disk_mb=1000, disk_mib=954
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Provided resources: mem_mb=12000, mem_mib=11445, disk_mb=1000, disk_mib=954
Select jobs to execute...

[Sat Mar  8 19:29:24 2025]
rule preprocess:
    input: /Genomics/argo/users/ms0270/git/darknps2/data/structures/final/smiles.csv
    output: /Genomics/skinniderlab/darknps2/clm/v1/prior/raw/smiles.txt
    jobid: 0
    reason: Forced execution
    wildcards: output_dir=/Genomics/skinniderlab/darknps2/clm/v1, dataset=smiles
    resources: mem_mb=12000, mem_mib=11445, disk_mb=1000, disk_mib=954, tmpdir=/tmp, slurm_partition=main,hoppertest,skinniderlab, runtime=30

reading NP model ...
model in
usage: clm [-h] [--version]
           {preprocess,create_training_sets,train_models_RNN,sample_molecules_RNN,tabulate_molecules,collapse_files,collect_tabulated_molecules,process_tabulated_molecules,write_structural_prior_CV,write_formula_prior_CV,calculate_outcomes,write_nn_Tc,write_freq_distribution,train_discriminator,calculate_outcome_distrs,add_carbon,forecast,plot}
           ...
clm: error: unrecognized arguments: --no_neutralise
[Sat Mar  8 19:29:31 2025]
Error in rule preprocess:
    jobid: 0
    input: /Genomics/argo/users/ms0270/git/darknps2/data/structures/final/smiles.csv
    output: /Genomics/skinniderlab/darknps2/clm/v1/prior/raw/smiles.txt
    shell:
        clm preprocess --seed 42 --input-file /Genomics/argo/users/ms0270/git/darknps2/data/structures/final/smiles.csv --output-file /Genomics/skinniderlab/darknps2/clm/v1/prior/raw/smiles.txt --min-heavy-atoms 3 --valid-atoms C H N O P S F Cl Br I Se Si --max-input-smiles 0 --no_neutralise
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
srun: error: argo-01: task 0: Exited with exit code 1
srun: launch/slurm: _step_signal: Terminating StepId=8015985.0
[Sat Mar  8 19:29:31 2025]
Error in rule preprocess:
    jobid: 0
    input: /Genomics/argo/users/ms0270/git/darknps2/data/structures/final/smiles.csv
    output: /Genomics/skinniderlab/darknps2/clm/v1/prior/raw/smiles.txt
    shell:
        clm preprocess --seed 42 --input-file /Genomics/argo/users/ms0270/git/darknps2/data/structures/final/smiles.csv --output-file /Genomics/skinniderlab/darknps2/clm/v1/prior/raw/smiles.txt --min-heavy-atoms 3 --valid-atoms C H N O P S F Cl Br I Se Si --max-input-smiles 0 --no_neutralise
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
```